### PR TITLE
split lesson02 into 2+1 sublessons to comply to the 7+2 rule

### DIFF
--- a/_extras/design.md
+++ b/_extras/design.md
@@ -60,7 +60,7 @@ Eric ran a large array of clinical trials in his hospital to improve children ph
 
 The following offers more details to each learning objective based on Bloom's Taxonomy. For hints on how to use this approach, see [lesson 15 of the instructor training](https://carpentries.github.io/instructor-training/15-lesson-study/index.html)
 
-### Prepare input data for use for deep learning
+### (lesson 1) Prepare input data for use for deep learning
 
 This includes cleaning data, filling missing values, normalizing, and transforming categorical columns into dummy encoding.
 
@@ -74,7 +74,7 @@ After this module, learners can ...
 - argue for or against strategies to normalize data
 - formulate techniques to prepare (clean) data for training a deep learning network
 
-### Design and train a Neural Network for tabular data
+### (lesson 2) Design and train a Neural Network for tabular data
 
 This includes knowledge for using a naive multilayer perceptron. __Which dataset to use?__
 
@@ -90,7 +90,7 @@ After this module, learners can ...
 - select a layer type depending on the input data
 - develop a 3-5 layer network 
 
-### Evaluate the performance of a classification network
+### (lesson 3) Evaluate the performance of a classification network
 
 How to judge the performance of a trained network.
 
@@ -105,7 +105,7 @@ After this module, learners can ...
 - describe how to split a dataset into training/test/validation set
 - execute a plot to draw the loss per epoch for training and test set
 
-### Design and train a Neural Network for image data
+### (lesson 4) Design and train a Neural Network for image data
 
 This lesson discusses convolutions in neural networks for image data. We will use the `cifar10` or `mnist` or `fashion_mnist` dataset coming with keras.
 
@@ -120,7 +120,7 @@ After this module, learners can ...
 - differentiate a dense layer and a convolutional layer
 
 
-### Monitoring and Troubleshooting the learning process
+### (lesson 5) Monitoring and Troubleshooting the learning process
 
 Often when designing neural networks training will not automatically work very well. This requires setting the parameters of the training algorithm correctly, modifying the design of the network or changing the data pre-processing. After training, the performance of the network should be checked to prevent overfitting.
 
@@ -134,7 +134,7 @@ After this module, learners can ...
 - critique a provided network design
 - describe how Drop-Out Layers work
 
-### Visualizing Data and Results
+### (lesson 6) Visualizing Data and Results
 
 Within each episode how to visualize data and results
 
@@ -146,7 +146,7 @@ After this module, learners can ...
 - examine the results of a partners network
 - critique the results of a partners network
 
-### Re-use existing network architectures with and without pre-trained weights
+### (lesson 7) Re-use existing network architectures with and without pre-trained weights
 
 Re-use of architectures is common in deep learning. Especially when using pre-trained weights (transfer-learning) it can also be very powerful.
 

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -47,7 +47,9 @@ Eric ran a large array of clinical trials in his hospital to improve children ph
 > After following this lesson, learners will be able to:
 >  
 > - Prepare input data for use for deep learning
-> - Design and train a Deep Neural Network
+> - Design and train a Neural Network for tabular data
+> - Evaluate the performance of a classification network
+> - Design and train a Neural Network for image data
 > - Troubleshoot the learning process
 > - Measure the performance of the network
 > - Visualizing data and results
@@ -88,7 +90,7 @@ After this module, learners can ...
 - select a layer type depending on the input data
 - develop a 3-5 layer network 
 
-### Evaluate the performance of a network
+### Evaluate the performance of a classification network
 
 How to judge the performance of a trained network.
 

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -72,27 +72,51 @@ After this module, learners can ...
 - argue for or against strategies to normalize data
 - formulate techniques to prepare (clean) data for training a deep learning network
 
-### Design and train a Deep Neural Network
+### Design and train a Neural Network for tabular data
 
-This includes knowledge of when to different types of layers
+This includes knowledge for using a naive multilayer perceptron. __Which dataset to use?__
 
 After this module, learners can ...
 
 - list/repeat the three ingredients to a feed forward network: input, hidden layers, output
 - classify/categorize parts of a feed forward network when presented a network architecture (as from `keras.model.summary()`)
 - describe a fully connected (dense) layer
-- describe a convolutional layer
-- describe a max pooling layer
 - describe an activation function
 - describe a softmax layer
 - argue against abundant use of the sigmoid function (exploding/vanishing gradients)
+- experiment with values of a dense layer
+- select a layer type depending on the input data
+- develop a 3-5 layer network 
+
+### Evaluate the performance of a network
+
+How to judge the performance of a trained network.
+
+After this module, learners can ...
+
+- calculate the accuracy of a classifier
+- describe the confusion matrix of a classification
+- sketch how precision, recall, f1 are calculated based on the confusion matrix
+- compare values of precision and recall
+- compare accuracy for different network architectures of the MLP
+- describe that during training the dataset needs to be split into 2 parts
+- describe how to split a dataset into training/test/validation set
+- execute a plot to draw the loss per epoch for training and test set
+
+### Design and train a Neural Network for image data
+
+This lesson discusses convolutions in neural networks for image data. We will use the `cifar10` or `mnist` or `fashion_mnist` dataset coming with keras.
+
+After this module, learners can ...
+
+- describe a convolutional layer
+- describe a max pooling layer
 - calculate the output data shape of an image when transformed by a fixed convolutional layer
 - interpret errors with convolutional layers
-- execute a 3 layer network on the MNIST data (or similar)
+- analyse advantages of convolutional layers with image input data or tabular input data
+- execute a 3-5 layer network on the MNIST data (or similar)
 - differentiate a dense layer and a convolutional layer
-- experiment with values of dense layer and a convolutional layer
-- select a layer type depending on the input data
-- develop a 5 layer network that comprises both layer types
+
 
 ### Monitoring and Troubleshooting the learning process
 
@@ -100,17 +124,13 @@ Often when designing neural networks training will not automatically work very w
 
 After this module, learners can ...
 
-- define precision and recall/accuracy for a classification task
 - state that cross-validation is used in Deep Learning too
-- describe how to split a dataset into training/test/validation set
-- describe how Drop-Out Layers work
-- execute a plot to draw the loss per epoch for training and test set
-- compare values of precision and recall
 - differentiate a overfitting network from a well-behaved network
 - detect when a network is underfitting or overfitting
 - design countermeasures for overfitting (e.g. more dropout layers, reduce model size)
 - design countermeasures for underfitting (e.g. larger model)
 - critique a provided network design
+- describe how Drop-Out Layers work
 
 ### Visualizing Data and Results
 
@@ -131,7 +151,7 @@ Re-use of architectures is common in deep learning. Especially when using pre-tr
 After this module, learners can ...
 
 - describe what transfer learning stands for
--  explain in what situations transfer learning is beneficial
+- explain in what situations transfer learning is beneficial
 - solve common issues of transfer learning (such as different resolutions of the original training and the training at hand)
 - test training under different data shape mitigation strategies
 - relate training time of a de-novo networt and a pretrained one

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -58,9 +58,9 @@ Eric ran a large array of clinical trials in his hospital to improve children ph
 {: .objectives }
 
 
-The following offers more details to each learning objective based on Bloom's Taxonomy. For hints on how to use this approach, see [lesson 15 of the instructor training](https://carpentries.github.io/instructor-training/15-lesson-study/index.html)
+The following offers more details to each learning objective based on Bloom's Taxonomy. For hints on how to use this approach, see [episode 15 of the instructor training](https://carpentries.github.io/instructor-training/15-lesson-study/index.html)
 
-### (lesson 1) Prepare input data for use for deep learning
+### (episode 1) Prepare input data for use for deep learning
 
 This includes cleaning data, filling missing values, normalizing, and transforming categorical columns into dummy encoding.
 
@@ -74,7 +74,7 @@ After this module, learners can ...
 - argue for or against strategies to normalize data
 - formulate techniques to prepare (clean) data for training a deep learning network
 
-### (lesson 2) Design and train a Neural Network for tabular data
+### (episode 2) Design and train a Neural Network for tabular data
 
 This includes knowledge for using a naive multilayer perceptron. __Which dataset to use?__
 
@@ -90,7 +90,7 @@ After this module, learners can ...
 - select a layer type depending on the input data
 - develop a 3-5 layer network 
 
-### (lesson 3) Evaluate the performance of a classification network
+### (episode 3) Evaluate the performance of a classification network
 
 How to judge the performance of a trained network.
 
@@ -105,9 +105,9 @@ After this module, learners can ...
 - describe how to split a dataset into training/test/validation set
 - execute a plot to draw the loss per epoch for training and test set
 
-### (lesson 4) Design and train a Neural Network for image data
+### (episode 4) Design and train a Neural Network for image data
 
-This lesson discusses convolutions in neural networks for image data. We will use the `cifar10` or `mnist` or `fashion_mnist` dataset coming with keras.
+This episode discusses convolutions in neural networks for image data. We will use the `cifar10` or `mnist` or `fashion_mnist` dataset coming with keras.
 
 After this module, learners can ...
 
@@ -120,7 +120,7 @@ After this module, learners can ...
 - differentiate a dense layer and a convolutional layer
 
 
-### (lesson 5) Monitoring and Troubleshooting the learning process
+### (episode 5) Monitoring and Troubleshooting the learning process
 
 Often when designing neural networks training will not automatically work very well. This requires setting the parameters of the training algorithm correctly, modifying the design of the network or changing the data pre-processing. After training, the performance of the network should be checked to prevent overfitting.
 
@@ -134,7 +134,7 @@ After this module, learners can ...
 - critique a provided network design
 - describe how Drop-Out Layers work
 
-### (lesson 6) Visualizing Data and Results
+### (episode 6) Visualizing Data and Results
 
 Within each episode how to visualize data and results
 
@@ -146,7 +146,7 @@ After this module, learners can ...
 - examine the results of a partners network
 - critique the results of a partners network
 
-### (lesson 7) Re-use existing network architectures with and without pre-trained weights
+### (episode 7) Re-use existing network architectures with and without pre-trained weights
 
 Re-use of architectures is common in deep learning. Especially when using pre-trained weights (transfer-learning) it can also be very powerful.
 


### PR DESCRIPTION
When trying to start working on lesson 02, I found that the current objectives are way too many for one lesson and decided to embrace the [7+2 rule](https://cdh.carpentries.org/developing-content.html#considering-cognitive-load). So I split lesson02 up into 3 parts:

- introduction of a simple MLP setup for tabular data
- performance evaluation of a classification using the confusion matrix
- introduction of a simple CNN

if this PR is merged, this would mean that #58 would have to be adapted.