### PR TITLE
Add event to trigger code check

### DIFF
--- a/.github/workflows/inline-code.yml
+++ b/.github/workflows/inline-code.yml
@@ -6,6 +6,7 @@ on:
       - main
       - code-check-action
   pull_request: []
+  workflow_dispatch:
 jobs:
   code-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Sometimes we want to trigger a code check without pushes / PRs, namely when the code checker is updated.

