### PR TITLE
Moving setting the optimizer to stage 5

### DIFF
--- a/_episodes/02-keras.md
+++ b/_episodes/02-keras.md
@@ -492,12 +492,8 @@ It is lower if the distributions are more similar.
 For more information on the available loss functions in Keras you can check the
 [documentation](https://www.tensorflow.org/api_docs/python/tf/keras/losses).
 
-## 6. Train model
-We are now ready to train the model.
-Training the model requires us to make a several more choices, this time we need to
-choose which optimizer to use and if this optimizer has parameters what values
-to use for those.
-Furthermore, we need to specify how many times to show the training samples to the optimizer.
+Next we need to choose which optimizer to use and if this optimizer has parameters what values
+to use for those. Furthermore, we need to specify how many times to show the training samples to the optimizer.
 
 Once more, Keras gives us plenty of choices all of which have their own pro's and cons,
 but for now let us go with the widely used Adam optimizer.
@@ -508,6 +504,14 @@ Combining this with the loss function we decided on earlier we can now compile t
 model using `model.compile`.
 Compiling the model prepares it to start the training.
 
+~~~
+model.compile(optimizer=keras.optimizers.Adam(), loss=keras.losses.CategoricalCrossentropy())
+~~~
+{:.language-python}
+
+## 6. Train model
+We are now ready to train the model.
+
 Training the model is done using the `fit` method, it takes the input data and
 target data as inputs and it has several other parameters for certain options
 of the training.
@@ -516,7 +520,6 @@ One training epoch means that every sample in the training data has been shown
 to the neural network and used to update its parameters.
 
 ~~~
-model.compile(optimizer=keras.optimizers.Adam(), loss=keras.losses.CategoricalCrossentropy())
 history = model.fit(X_train, y_train, epochs=100)
 ~~~
 {:.language-python}


### PR DESCRIPTION
All text and code relating to setting the optimizer are now moved into stage 5 of the process (choose a loss function and optimizer) instead of stage 6 (train the model).

fixes #85 