### PR TITLE
fixing code to pass checker

### DIFF
--- a/_episodes/03-monitor-the-model.md
+++ b/_episodes/03-monitor-the-model.md
@@ -265,9 +265,7 @@ In the given case we want to stimulate that the predicted values are as close as
 In Keras this is implemented in the `keras.losses.MeanSquaredError` class (see Keras documentation: https://keras.io/api/losses/). This can be provided into the `model.compile` method with the `loss` parameter and setting it to `mse`, e.g. 
 
 ~~~
-model.compile(#...
-              loss='mse',
-              #...)
+model.compile(loss='mse')
 ~~~
 {: .language-python}
 
@@ -278,8 +276,7 @@ The *optimizer* here refers to the algorithm with which the model learns to opti
 
 ~~~
 model.compile(optimizer='adam',
-              loss='mse',
-              #...)
+              loss='mse')
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
This changes 

model.compile(#...
              loss='mse',
              #...)

to just

model.compile( loss='mse')

(and the same for the following example with the optimizer)

to make it pass the code check by using syntactically valid python. Is this acceptable or does it make it harder for a learner to understand?

We could also avoid this issue by not marking it as a python block of code or simply not presenting the full statement until we've covered both the loss and optimizer. 