### PR TITLE
Fix typos #213 Episode 3

### DIFF
--- a/_episodes/03-monitor-the-model.md
+++ b/_episodes/03-monitor-the-model.md
@@ -80,7 +80,7 @@ Index(['DATE', 'MONTH', 'BASEL_cloud_cover', 'BASEL_humidity',
 >
 > * How many data points do we have?
 > * How many features does the data have (don't count month and date as a feature)?
-> * What are the different measured variabel types in the data and how many are there (humidity etc.) ?
+> * What are the different measured variable types in the data and how many are there (humidity etc.) ?
 >
 > > ## Solution
 > > ~~~
@@ -164,7 +164,7 @@ Setting the `random_state` to `0` is a short-hand at this point. Note however, t
 > We have been rather generous at selecting rows from the dataset. Our holdout set above amounts to almost an entire year of data. How would the code need to be rewritten in order to obtain two months of data for the validation and test set each?
 >
 > 1. `X_train, X_holdout ... = train_test_split( ..., test_size = .12, ...)`  
-> ``X_val, X_test ... = train_test_split( ..., test_size = 2, ...)`
+> `X_val, X_test ... = train_test_split( ..., test_size = 2, ...)`
 >
 > 2. `X_train, X_holdout ... = train_test_split( ..., test_size = .33, ...)`  
 > `X_val, X_test ... = train_test_split( ..., test_size = .33, ...)`
@@ -430,7 +430,7 @@ Judging from the numbers alone, our neural network preduction would be performin
 
 ## Watch your model training closely
 
-As we saw when comparing the predictions for the training and the test set, deep learning models are prone to overfitting. Instead of iterating through countless cycles of model trainings and subsequent evaluations with a reserved test set, it is common practice to work with a second split off dataset to monitor the model during training. This is the *validation set* which can be regarded as a second test set. As with the test set the datapoints of the *validation set* are not used for the actual model training itself. Instead we evaluate the model with the *validation set* after every epoch during training, for instance to splot if we see signs of clear overfitting.
+As we saw when comparing the predictions for the training and the test set, deep learning models are prone to overfitting. Instead of iterating through countless cycles of model trainings and subsequent evaluations with a reserved test set, it is common practice to work with a second split off dataset to monitor the model during training. This is the *validation set* which can be regarded as a second test set. As with the test set the datapoints of the *validation set* are not used for the actual model training itself. Instead we evaluate the model with the *validation set* after every epoch during training, for instance to split if we see signs of clear overfitting.
 
 Let's give this a try!
 
@@ -584,7 +584,7 @@ model.compile(optimizer='adam',
 
 To apply early stopping during training it is easiest to use Keras `EarlyStopping` class.
 This allows to define the condition of when to stop training. In our case we will say when the validation loss is lowest.
-However, since we have seen quiet some fluctuation of the losses during training above we will also set `patience=10` which means that the model will stop training of the validation loss has not gone down for 10 epochs.
+However, since we have seen quiet some fluctuation of the losses during training above we will also set `patience=10` which means that the model will stop training if the validation loss has not gone down for 10 epochs.
 ~~~
 from tensorflow.keras.callbacks import EarlyStopping
 


### PR DESCRIPTION
### Fixed Typos:

> Episode 3 explore the dataset exercise "variabel types" _**- changed to 'variable'**_
> Episode 3 "Split data into training, validation, and test set" exercise has an extra "`" to format code _**- removed grave symbol**_
> Episode 3 "to splot if" _**- changed to 'split'**_
> Episode 3 "stop training of the" _**- changed to 'if'**_
