### PR TITLE
Fix typos #213 Episode 4

### DIFF
--- a/_episodes/04-networks-are-like-onions.md
+++ b/_episodes/04-networks-are-like-onions.md
@@ -167,7 +167,7 @@ print(dim)
 >
 > > ## Solution
 > >
-> > Each entry of the input dimensions, i.e. the `shape` of one signal data point, is connected with 100 neurons of our hidden layer, and each of these neurons has a bias term associated to it. So we have `307300` parameters to learn.
+> > Each entry of the input dimensions, i.e. the `shape` of one single data point, is connected with 100 neurons of our hidden layer, and each of these neurons has a bias term associated to it. So we have `307300` parameters to learn.
 > > ~~~
 > > width, height = (32, 32)
 > > n_hidden_neurons = 100
@@ -382,7 +382,7 @@ It seems that the model is overfitting somewhat, because the validation accuracy
 > {: language-python}
 > >
 > > ## Solution
-> > We add a an extra Conv2D layer after the second pooling layer:
+> > We add an extra Conv2D layer after the second pooling layer:
 > > ~~~
 > > inputs = keras.Input(shape=train_images.shape[1:])
 > > x = keras.layers.Conv2D(32, (3, 3), activation='relu')(inputs)


### PR DESCRIPTION
### Fixed Typo:

> Episode 4 solution "one signal data point" _**- Changed to 'single'**_
> Episode 4 solution "add a an extra" _**- Removed 'a'**_
