### PR TITLE
324 binder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/carpentries-incubator/deep-learning-intro/scaffolds)
+
 # Introduction to deep learning
 This lesson gives an introduction to deep learning.
 

--- a/setup.md
+++ b/setup.md
@@ -174,7 +174,7 @@ Most versions will work fine with this lesson, but:
 - For sklearn, the minimum version is 0.22.
 
 ## Fallback option: cloud environment
-If a local installation does not work for you, it is also possible to run this lesson in [Binder Hub](https://mybinder.org/v2/gh/carpentries-incubator/deep-learning-intro/scaffolds). This should give you an environment with all the required software and data to run this lesson, nothing which is saved will be stored, please copy any files you want to keep. 
+If a local installation does not work for you, it is also possible to run this lesson in [Binder Hub](https://mybinder.org/v2/gh/carpentries-incubator/deep-learning-intro/scaffolds). This should give you an environment with all the required software and data to run this lesson, nothing which is saved will be stored, please copy any files you want to keep. Note that if you are the first person to launch this in the last few days it can take several minutes to startup. The second person who loads it should find it loads in under a minute. Instructors who intend to use this option should start it themselves shortly before the workshop begins.
 
 Alternatively you can use [Google colab](https://colab.research.google.com/). If you open a jupyter notebook here, the required packages are already pre-installed. Note that google colab uses jupyter notebook instead of jupyter lab.
 

--- a/setup.md
+++ b/setup.md
@@ -174,7 +174,9 @@ Most versions will work fine with this lesson, but:
 - For sklearn, the minimum version is 0.22.
 
 ## Fallback option: cloud environment
-If a local installation does not work for you, it is also possible to run this lesson in [Google colab](https://colab.research.google.com/). If you open a jupyter notebook here, the required packages are already pre-installed. Note that google colab uses jupyter notebook instead of jupyter lab.
+If a local installation does not work for you, it is also possible to run this lesson in [Binder Hub](https://mybinder.org/v2/gh/carpentries-incubator/deep-learning-intro/scaffolds). This should give you an environment with all the required software and data to run this lesson, nothing which is saved will be stored, please copy any files you want to keep. 
+
+Alternatively you can use [Google colab](https://colab.research.google.com/). If you open a jupyter notebook here, the required packages are already pre-installed. Note that google colab uses jupyter notebook instead of jupyter lab.
 
 ## Downloading the required datasets
 


### PR DESCRIPTION
This makes the Binder Hub links more prominent by adding them to the readme and setup instructions. This can be used as a fallback environment for anybody who can't install anaconda on their own computer. 