### PR TITLE
installed packages versions updated

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -262,9 +262,9 @@ Follow the instructions in the [setup]({{ page.root }}//setup) document to insta
 > ~~~
 > {:.language-python}
 > > ## Solution
-> > You should get a version number reported. At the time of writing 2.4.0 is the latest version.
+> > You should get a version number reported. At the time of writing 2.12.0 is the latest version.
 > > ~~~
-> > 2.4.0
+> > 2.12.0
 > > ~~~
 > > {:.output}
 > {:.solution}
@@ -279,9 +279,9 @@ Follow the instructions in the [setup]({{ page.root }}//setup) document to insta
 > ~~~
 > {:.language-python}
 > > ## Solution
-> > You should get a version number reported. At the time of writing 0.11.1 is the latest version.
+> > You should get a version number reported. At the time of writing 0.12.2 is the latest version.
 > > ~~~
-> > 0.11.1
+> > 0.12.2
 > > ~~~
 > > {:.output}
 > {:.solution}
@@ -297,9 +297,9 @@ Follow the instructions in the [setup]({{ page.root }}//setup) document to insta
 > ~~~
 > {:.language-python}
 > > ## Solution
-> > You should get a version number reported. At the time of writing 0.24.1 is the latest version.
+> > You should get a version number reported. At the time of writing 1.2.2 is the latest version.
 > > ~~~
-> > 0.24.1
+> > 1.2.2
 > > ~~~
 > > {:.output}
 > {:.solution}

--- a/setup.md
+++ b/setup.md
@@ -170,8 +170,8 @@ print('Tensorflow version: ', tensorflow.__version__)
 
 This should output the versions of all required packages without giving errors.
 Most versions will work fine with this lesson, but:
-- For Keras and Tensorflow, the minimum version is 2.2.4
-- For sklearn, the minimum version is 0.22.
+- For Keras and Tensorflow, the minimum version is 2.12.0
+- For sklearn, the minimum version is 1.2.2
 
 ## Fallback option: cloud environment
 If a local installation does not work for you, it is also possible to run this lesson in [Google colab](https://colab.research.google.com/). If you open a jupyter notebook here, the required packages are already pre-installed. Note that google colab uses jupyter notebook instead of jupyter lab.


### PR DESCRIPTION
Fixes #320 

At the time, the latest package versions are:

sklearn version:  1.2.2
seaborn version:  0.12.2
pandas version:  1.5.3
Keras version:  2.12.0
Tensorflow version:  2.12.0


![image](https://github.com/carpentries-incubator/deep-learning-intro/assets/999243/ab79d2c9-1367-4c7f-9ba2-9402f7b8ba9f)

