### PR TITLE
link out to DC Image curriculum

### DIFF
--- a/_episodes/04-advanced-layer-types.md
+++ b/_episodes/04-advanced-layer-types.md
@@ -269,6 +269,9 @@ In our **convolutional layer** our hidden units are a number of convolutional ma
 > > You can ignore them, which means that your output image is slightly smaller then your input.
 > > It is also possible to 'pad' the borders, e.g. with the same value or with zeros, so that the convolution can also be applied to the border pixels.
 > > In that case, the output image will have the same size as the input image.
+> > [A callout in the Data Carpentry: Image Processing with Python curriculum](https://datacarpentry.org/image-processing/06-blurring.html#callout4)
+> > provides more detail about convolution at the boundaries of an image,
+> > in the context of applying a _Gaussian blur_.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
This PR links out to a more detailed description of how convolution (in the form of a Gaussian blur) can be applied at the boundaries of an image. Related to discussion in #287 
