### PR TITLE
Shorten data exploration in episode 2, 3 and 4

### DIFF
--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -112,6 +112,7 @@ penguins.head()
  All columns but the 'species' columns are features that we can use.
 
 There are 344 samples and 7 columns, so 6 features:
+
  ```python
  penguins.shape
  ```

--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -95,20 +95,8 @@ penguins = sns.load_dataset('penguins')
 
 This will give you a pandas dataframe which contains the penguin data.
 
-::: challenge
-## Penguin Dataset
-
-Inspect the penguins dataset.
-
-1. What are the different features called in the dataframe?
-2. Are the target classes of the dataset stored as numbers or strings?
-3. How many samples does this dataset have?
-
-:::: solution
-
-## Solution
-**1.** Using the pandas `head` function you can see the names of the features.
-Using the `describe` function we can also see some statistics for the numeric columns
+### Inspecting the data
+Using the pandas `head` function gives us a quick look at the data:
 ```python
 penguins.head()
 ```
@@ -121,48 +109,15 @@ penguins.head()
  | 3 | Adelie | Torgersen | NaN  | NaN  | NaN   | NaN    | NaN    |
  | 4 | Adelie | Torgersen | 36.7 | 19.3 | 193.0 | 3450.0 | Female |
 
+ All columns but the 'species' columns are features that we can use.
+
+There are 344 samples and 7 columns, so 6 features:
  ```python
- penguins.describe()
+ penguins.shape
  ```
- 
-
- |       | bill_length_mm | bill_depth_mm | flipper_length_mm | body_mass_g |
- |------:|---------------:|--------------:|------------------:|------------:|
- | count |     342.000000 |    342.000000 |        342.000000 |  342.000000 |
- |  mean |      43.921930 |     17.151170 |        200.915205 | 4201.754386 |
- |   std |       5.459584 |      1.974793 |         14.061714 |  801.954536 |
- |   min |      32.100000 |     13.100000 |        172.000000 | 2700.000000 |
- |   25% |      39.225000 |     15.600000 |        190.000000 | 3550.000000 |
- |   50% |      44.450000 |     17.300000 |        197.000000 | 4050.000000 |
- |   75% |      48.500000 |     18.700000 |        213.000000 | 4750.000000 |
- |   max |      59.600000 |     21.500000 |        231.000000 | 6300.000000 |
-
-**2.** We can get the unique values in the `species` column using the `unique` function of pandas.
-It shows the target class is stored as a string and has 3 unique values. This type of column is
-usually called a 'categorical' column.
-```python
-penguins["species"].unique()
-```
-```output
-array(['Adelie', 'Chinstrap', 'Gentoo'], dtype=object)
-```
-
-**3.** Using `describe` function on the species column shows there are 344 samples
-unique species
-```python
-penguins["species"].describe()
-```
-
-```output
-count        344
-unique         3
-top       Adelie
-freq         152
-Name: species, dtype: object
-```
-
-::::
-:::
+ ```output
+ (344, 7)
+ ```
 
 ### Visualization
 Looking at numbers like this usually does not give a very good intuition about the data we are
@@ -220,14 +175,24 @@ penguins['species'] = penguins['species'].astype('category')
 
 This will make later interaction with this column a little easier.
 
+For now we will only use the numerical features `bill_length_mm`, `bill_depth_mm`, `flipper_length_mm`, `body_mass_g` only,
+so let's drop the categorical columns:
+```python
+# Drop categorical columns
+penguins_filtered = penguins.drop(columns=['island', 'sex'])
+```
+
 ### Clean missing values
 During the exploration phase you may have noticed that some rows in the dataset have missing (NaN)
 values, leaving such values in the input data will ruin the training, so we need to deal with them.
 There are many ways to deal with missing values, but for now we will just remove the offending rows by adding a call to `dropna()`:
 ```python
-# Drop two columns and the rows that have NaN values in them
-penguins_filtered = penguins.drop(columns=['island', 'sex']).dropna()
+# Drop the rows that have NaN values in them
+penguins_filtered = penguins_filtered.dropna()
+```
 
+Finally, we select only the features
+```python
 # Extract columns corresponding to features
 penguins_features = penguins_filtered.drop(columns=['species'])
 ```
@@ -254,28 +219,17 @@ target.head() # print out the top 5 to see what it looks like.
 ```
 
 ::: challenge
-## One-hot encoding vs ordinal encoding
-1. How many output neurons will our network have now that we
-  one-hot encoded the target class?
-2. Another encoding method is 'ordinal encoding'.
-  Here the variable is represented by a single column,
-  where each category is represented by a different integer
-  (0, 1, 2 in the case of the 3 penguin species).
-  How many output neurons will a network have when ordinal encoding is used?
-3. (Optional) What would be the advantage of using one-hot versus ordinal encoding
-  for the task of classifying penguin species?
+## One-hot encoding
+How many output neurons will our network have now that we one-hot encoded the target class?
+
+* A: 1
+* B: 2
+* C: 3
 
 :::: solution
 ## Solution
-1. 3, one for each output variable class
-2. 1, the 3 classes are represented in a single variable
-3. In this case there is no ordinal relationship between the different penguin species,
-  so it does not make sense to use ordinal encoding.
-  To give an intuition of how a machine learning model deals with ordinal encoding:
-  Let us say that the model predicted 0 (Gentoo) instead of the true value 2 (Adélie),
-  the error would in this case be 2 (2-0). But if the prediction would be 1 (Chinstrap),
-  the error would be 1 (2-1). A missclassification between Gentoo and Adélie would then
-  thus contribute more to the overall error than missclassificaiton between Chinstrap and Adélie!
+3, one for each output variable class
+
 ::::
 :::
 
@@ -305,33 +259,6 @@ from sklearn.model_selection import train_test_split
 
 X_train, X_test, y_train, y_test = train_test_split(penguins_features, target,test_size=0.2, random_state=0, shuffle=True, stratify=target)
 ```
-::: challenge
-## Training and Test sets
-Take a look at the training and test set we created.
-- How many samples do the training and test sets have?
-- Are the classes in the training set well balanced?
-
-:::: solution
-## Solution
-Using `y_train.shape` and `y_test.shape` we can see the training set has 273
-samples and y_test has 69 samples.
-We can check the balance of classes by counting the number of ones for each
-of the columns in the one-hot-encoded target,
-which shows the training set has 121 Adelie, 98 Gentoo and 54 Chinstrap samples.
-```python
-y_train.sum()
-```
-```output
-Adelie       121
-Chinstrap     54
-Gentoo        98
-dtype: int64
-```
-
-The dataset is not perfectly balanced, but it is not orders of magnitude out of balance
-either. So we will leave it as it is.
-::::
-:::
 
 ## 4. Build an architecture from scratch or choose a pretrained model
 

--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -132,6 +132,7 @@ sns.pairplot(penguins, hue="species")
 ![][pairplot]
 
 ::: challenge
+
 ## Pairplot
 
 Take a look at the pairplot we created. Consider the following questions:

--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -116,9 +116,6 @@ There are 344 samples and 7 columns, so 6 features:
  ```python
  penguins.shape
  ```
- ```output
- (344, 7)
- ```
 
 ### Visualization
 Looking at numbers like this usually does not give a very good intuition about the data we are

--- a/episodes/3-monitor-the-model.Rmd
+++ b/episodes/3-monitor-the-model.Rmd
@@ -82,7 +82,7 @@ Index(['DATE', 'MONTH', 'BASEL_cloud_cover', 'BASEL_humidity',
        'TOURS_temp_mean', 'TOURS_temp_min', 'TOURS_temp_max'],
       dtype='object')
 ```
-There is a total of 9 different measured variables (global_readation, humidity, etcetera)
+There is a total of 9 different measured variables (global_radiation, humidity, etcetera)
 
 
 Let's have a look at the shape of the dataset:

--- a/episodes/3-monitor-the-model.Rmd
+++ b/episodes/3-monitor-the-model.Rmd
@@ -82,55 +82,18 @@ Index(['DATE', 'MONTH', 'BASEL_cloud_cover', 'BASEL_humidity',
        'TOURS_temp_mean', 'TOURS_temp_min', 'TOURS_temp_max'],
       dtype='object')
 ```
+There is a total of 9 different measured variables (global_readation, humidity, etcetera)
 
-::: challenge
-## Exercise: Explore the dataset
-Let's get a quick idea of the dataset.
 
-* How many data points do we have?
-* How many features does the data have (don't count month and date as a feature)?
-* What are the different types of measurements (humidity etc.) in the data and how many are there?
-* (Optional) Plot the amount of sunshine hours in Basel over the course of a year. Are there any interesting properties that you notice?
-
-:::: solution
-
-## Solution
+Let's have a look at the shape of the dataset:
 ```python
 data.shape
 ```
-This will give both the number of datapoints (3654) and the number of features (89 + month +
-te).
-To see what type of features the data contains we could run something like:
-```python
-import string
-print({x.lstrip(string.ascii_uppercase + "_") for x in data.columns if x not in ["MONTH", "DATE"]})
-```
 ```output
-{'cloud_cover', 'precipitation', 'sunshine', 'global_radiation', 'temp_mean', 'humidity', 'pressure', 'temp_min', 'temp_max'}
+(3654, 91)
 ```
-An alternative way which is slightly more complicated but gives better results is using regex.
-```python
-import re
-feature_names = set()
-for col in data.columns:
-   feature_names.update(re.findall('[^A-Z]{2,}', col))
-feature_names
-```
-In total there are 9 different measured variables.
-
-### Optional exercise
-You can plot the sunshine hours in Basel as follows:
-```python
-data.iloc[:365]['BASEL_sunshine'].plot(xlabel="Day",ylabel="Basel sunchine hours")
-```
-
-![](../fig/03_exploration_basel_sunshine_graph.png){alt='Plot of Basel sunshine hours in one year'}
-
-There are a couple of things that might stand out to you. For example, it looks like the sunshine
-hours are fluctuating a lot per day. There also seems to be seasonal fluctuation, with the peaks
-becoming higher around the middle of the year.
-::::
-:::
+This will give both the number of samples (3654) and the number of features (89 + month +
+date).
 
 ## 3. Prepare data
 
@@ -138,9 +101,10 @@ becoming higher around the middle of the year.
 The full dataset comprises of 10 years (3654 days) from which we will select only the first 3 years. The present dataset is sorted by "DATE", so for each row `i` in the table we can pick a corresponding feature and location from row `i+1` that we later want to predict with our model. As outlined in step 1, we would like to predict the sunshine hours for the location: BASEL.
 
 ```python
-nr_rows = 365*3
+nr_rows = 365*3 # 3 years
 # data
-X_data = data.loc[:nr_rows].drop(columns=['DATE', 'MONTH'])
+X_data = data.loc[:nr_rows] # Select first 3 years
+X_data = X_data.drop(columns=['DATE', 'MONTH']) # Drop date and month column
 
 # labels (sunshine hours the next day)
 y_data = data.loc[1:(nr_rows + 1)]["BASEL_sunshine"]

--- a/episodes/4-advanced-layer-types.Rmd
+++ b/episodes/4-advanced-layer-types.Rmd
@@ -140,8 +140,6 @@ train_images = train_images / 255.0
 test_images = test_images / 255.0
 ```
 
-![](../fig/04_cifar10.png){alt="A 5 by 5 grid of 25 sample images from the CIFAR-10 data-set. Each image is labelled with a category, for example: 'frog' or 'horse'."}
-
 ## 4. Choose a pretrained model or start building architecture from scratch
 
 ## Convolutional layers

--- a/episodes/4-advanced-layer-types.Rmd
+++ b/episodes/4-advanced-layer-types.Rmd
@@ -136,7 +136,7 @@ test_images = test_images / 255.0
 
 ## Convolutional layers
 In the previous episodes, we used 'fully connected layers' , that connected all input values of a layer to all outputs of a layer.
-This results in many connections, and thus weights to be learned, in the network.
+This results in many connections, and thus many weights to be learned, in the network.
 Note that our input dimension is now quite high (even with small pictures of `32x32` pixels): we have 3072 features.
 
 ::: challenge

--- a/episodes/4-advanced-layer-types.Rmd
+++ b/episodes/4-advanced-layer-types.Rmd
@@ -35,6 +35,18 @@ from tensorflow import keras
 ```
 
 ::: callout
+## CERTIFICATE_VERIFY_FAILED error when downloading CIFAR-10 dataset
+When loading the CIFAR-10 dataset, you might get the following error:
+```
+[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1125)
+```
+You can solve this error by adding this to your notebook:
+```python
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+```
+:::
+
 ## CIFAR-10
 
 The CIFAR-10 dataset consists of images of 10 different classes: airplanes, cars, birds, cats, deer, dogs, frogs, horses, ships, and trucks.
@@ -42,21 +54,9 @@ It is widely used as a benchmark dataset for image classification. The low resol
 
 For more information about this dataset and how it was collected you can check out
 [Learning Multiple Layers of Features from Tiny Images by  Alex Krizhevsky, 2009](https://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf).
-:::
 
-::: callout
-## CERTIFICATE_VERIFY_FAILED error when downloading CIFAR-10 dataset
-When loading the CIFAR-10 dataset, you might get the following error:
-```
-[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1125)
-```
 
-You can solve this error by adding this to your notebook:
-```python
-import ssl
-ssl._create_default_https_context = ssl._create_unverified_context
-```
-:::
+![Sample images from the CIFAR-10 data-set. Each image is labelled with a category, for example: 'frog' or 'horse'](../fig/04_cifar10.png){alt="A 5 by 5 grid of 25 sample images from the CIFAR-10 data-set. Each image is labelled with a category, for example: 'frog' or 'horse'."}
 
 We take a small sample of the data as training set for demonstration purposes.
 ```python
@@ -65,22 +65,9 @@ train_images = train_images[:n]
 train_labels = train_labels[:n]
 ```
 
-::: challenge
 ## Explore the data
-Familiarize yourself with the CIFAR10 dataset. To start, consider the following questions:
 
-1. What is the dimension of a single data point? What do you think the dimensions mean?
-2. What is the range of values that your input data takes?
-3. What is the shape of the labels, and how many labels do we have?
-4. (Optional) We are going to build a new architecture from scratch to get you
-  familiar with the convolutional neural network basics.
-  But in the real world you wouldn't do that.
-  So the challenge is: Browse the web for (more) existing architectures or pre-trained models that are likely to work
-  well on this type of data. Try to understand why they work well for this type of data.
-  
-:::: solution
-## Solution
-To explore the dimensions of the input data:
+Let's do a quick exploration of the dimensions of the data:
 ```python
 train_images.shape
 ```
@@ -92,7 +79,26 @@ The first value, `5000`, is the number of training images that we have selected.
 The remainder of the shape, namely `32, 32, 3)`, denotes
 the dimension of one image. The last value 3 is typical for color images,
 and stands for the three color channels **R**ed, **G**reen, **B**lue.
-We are left with `32, 32`. This denotes the width and height of our input image in number of pixels. By convention, the first entry refers to the height, the second to the width of the image. In this case, we observe a quadratic image where height equals width.
+
+::: challenge
+
+## Number of features CIFAR-10
+
+How many features does one image in the CIFAR-10 dataset have?
+
+- A. 32
+- B. 1024
+- C. 3072
+- D. 5000
+
+
+:::: solution
+The correct solution is C: 3072. There are 1024 pixels in one image (32 * 32),
+each pixel has 3 channels (RGB). So 1024 * 3 = 3072.
+::::
+:::
+
+
 We can find out the range of values of our input data as follows:
 ```python
 train_images.min(), train_images.max()
@@ -121,53 +127,17 @@ train_labels.min(), train_labels.max()
 
 The values of the labels range between `0` and `9`, denoting 10 different classes.
 
-::::
-:::
-
-
-The training set consists of 50000 images of `32x32` pixels and 3 channels (RGB values). The RGB values are between `0` and `255`. For input of neural networks, it is better to have small input values. So we normalize our data between `0` and `1`:
-
+For input of neural networks, it is better to have small input values. So we normalize our data between `0` and `1`:
 
 ```python
 train_images = train_images / 255.0
 test_images = test_images / 255.0
 ```
 
-The labels are single numbers denoting the class.
-We map the class numbers back to the class names, taken from the documentation:
-
-```python
-class_names = ['airplane', 'automobile', 'bird', 'cat', 'deer',
-               'dog', 'frog', 'horse', 'ship', 'truck']
-```
-
-
-Now we can plot a sample of the training images, using the `plt.imshow` function.
-```python
-import matplotlib.pyplot as plt
-plt.figure(figsize=(10,10))
-for i in range(25):
-    plt.subplot(5,5,i+1)
-    plt.imshow(train_images[i], cmap=plt.cm.binary)
-    plt.axis('off')
-    plt.title(class_names[train_labels[i,0]])
-plt.show()
-```
-
-
-![](../fig/04_cifar10.png){alt="A 5 by 5 grid of 25 sample images from the CIFAR-10 data-set. Each image is labelled with a category, for example: 'frog' or 'horse'."}
-
 ## Convolutional layers
-In the previous episodes, we used 'fully connected layers' , that connected all input values of a layer to all outputs of a layer. This results in many connections, and thus weights to be learned, in the network. Note that our input dimension is now quite high (even with small pictures of `32x32` pixels), we have:
-
-
-```python
-dim = train_images.shape[1] * train_images.shape[2] * train_images.shape[3]
-print(dim)
-```
-```output
-3072
-```
+In the previous episodes, we used 'fully connected layers' , that connected all input values of a layer to all outputs of a layer.
+This results in many connections, and thus weights to be learned, in the network.
+Note that our input dimension is now quite high (even with small pictures of `32x32` pixels): we have 3072 features.
 
 ::: challenge
 ## Number of parameters


### PR DESCRIPTION
Greatly reduces the time spent on data exploration and processing, so that there is more time for deep learning!
In general I moved stuff out of exercises, and added a simple MC question instead to activate everyone. This should greatly improve the speed!

In episode 4 I also removed plotting the images, we want people to learn deep learning and not how to plot images (even though it is a lot of fun of course)

Fixes #258 