### PR TITLE
Bug fix: random seed for keras

### DIFF
--- a/episodes/2-keras.Rmd
+++ b/episodes/2-keras.Rmd
@@ -276,8 +276,7 @@ Therefore we will need to set two random seeds, one for numpy and one for tensor
 ```python
 from numpy.random import seed
 seed(1)
-from tensorflow.random import set_seed
-set_seed(2)
+keras.utils.set_random_seed(2)
 ```
 
 ### Build a neural network from scratch


### PR DESCRIPTION
This PR fixes a bug in step 4 of episode 2. Here two seeds are set to ensure consistent results. However the second seed is not correct or depricated
`from tensorflow.random import set_seed
set_seed(2)`

instead the `keras.utils.set_random_seed` should be used to ensure consistent results. The first seed from numpy is also still neccesary.

fixes #388 