### PR TITLE
436 update libraries and check if code examples still work

### DIFF
--- a/episodes/1-introduction.Rmd
+++ b/episodes/1-introduction.Rmd
@@ -424,16 +424,16 @@ Keras also benefits from a very good set of [online documentation](https://keras
 Follow the instructions in the [setup]({{ page.root }}//setup) document to install Keras, Seaborn and Sklearn.
 
 ## Testing Keras Installation
-Lets check you have a suitable version of Keras installed.
+Lets check you have a suitable version of tensorflow installed.
 Open up a new Jupyter notebook or interactive python console and run the following commands:
 ```python
-from tensorflow import keras
-print(keras.__version__)
+import tensorflow
+print(tensorflow.__version__)
 ```
 ```output
-2.12.0
+2.15.0
 ```
-You should get a version number reported. At the time of writing 2.12.0 is the latest version.
+You should get a version number reported. At the time of writing 2.15.0 is the latest version.
 
 ## Testing Seaborn Installation
 Lets check you have a suitable version of seaborn installed.

--- a/episodes/4-advanced-layer-types.Rmd
+++ b/episodes/4-advanced-layer-types.Rmd
@@ -172,7 +172,7 @@ n_parameters
 ```
 We can also check this by building the layer in Keras:
 ```python
-inputs = keras.Input(shape=dim)
+inputs = keras.Input(shape=n_input_items)
 outputs = keras.layers.Dense(100)(inputs)
 model = keras.models.Model(inputs=inputs, outputs=outputs)
 model.summary()

--- a/episodes/4-advanced-layer-types.Rmd
+++ b/episodes/4-advanced-layer-types.Rmd
@@ -494,8 +494,8 @@ As you can see this model has 1.5x more parameters than our simple CNN, let's tr
 ```python
 compile_model(dense_model)
 history = dense_model.fit(train_images, train_labels, epochs=30,
-                    validation_data=(test_images, test_labels))
-plot_history(['accuracy', 'val_accuracy'])
+                    validation_data=(val_images, val_labels))
+plot_history(history, ['accuracy', 'val_accuracy'])
 ```
 ![](fig/04_dense_model_training_history.png){alt="Plot of training accuracy and validation accuracy vs epochs for a model with only dense layers"}
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -176,9 +176,6 @@ print('seaborn version: ', seaborn.__version__)
 import pandas
 print('pandas version: ', pandas.__version__)
 
-from tensorflow import keras
-print('Keras version: ', keras.__version__)
-
 import tensorflow
 print('Tensorflow version: ', tensorflow.__version__)
 ```


### PR DESCRIPTION
The api of keras has stayed the same thankfully. Only the version check of keras didn't exist anymore, but a version check of tensorflow show be sufficient.

I also fixed some small bugs that I encountered.