### PR TITLE
Remove schedule.md from config.yaml.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -71,7 +71,6 @@ learners:
 
 # Information for Instructors
 instructors:
-- schedule.md
 
 # Learner Profiles
 profiles:


### PR DESCRIPTION
`schedule.md` should not be in the `instructors` section, this fixes #458 .
