### PR TITLE
Fix links to software setup.

### DIFF
--- a/episodes/1-introduction.Rmd
+++ b/episodes/1-introduction.Rmd
@@ -456,10 +456,10 @@ Keras also benefits from a very good set of [online documentation](https://keras
 
 ### Installing Keras and other dependencies
 
-Follow the instructions in the [setup]({{ page.root }}//setup) document to install Keras, Seaborn and scikit-learn.
+Follow the instructions in the [setup](/#software-setup) document to install Keras, Seaborn and scikit-learn.
 
 ## Testing Keras Installation
-Keras is available as a module within TensorFlow, as described in the [setup]({{ page.root }}//setup).
+Keras is available as a module within TensorFlow, as described in the [setup](/#software-setup).
 Let's therefore check whether you have a suitable version of TensorFlow installed.
 Open up a new Jupyter notebook or interactive python console and run the following commands:
 ```python


### PR DESCRIPTION
There seem to be two issues here:
- The string ``{{ page.root }}` is not resolved, but becomes part of the literal URL in the rendered HTML
- The anchor is called `software-setup`, not `setup`

Fixes #502 

 ## Notes for Reviewer
The proposed fix is to remove the `{{ page.root }}` entirely. This works locally, but I am not entirely certain about potential side effects.